### PR TITLE
Allow "help" subcommands to display output

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ WORKDIR /tmp
 
 RUN apk --no-cache add \
       bash \
+      groff \
       curl \
       jq \
       py-pip \


### PR DESCRIPTION
Why:
- Running "docker run ... aws s3 help" (or any help subcommand) results
  in an error message 'Could not find executable named "groff"'.
- groff is the typesetting program used by "man" and (apparently) "aws
  help"

This change addresses the need by:
- Adding groff to the list of packages installed to the base alpine
  image.
