### PR TITLE
Allow running help subcommands

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ WORKDIR /tmp
 
 RUN apk --no-cache add \
       bash \
+      groff \
       curl \
       jq \
       py-pip \

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ WORKDIR /tmp
 RUN apk --no-cache add \
       bash \
       groff \
+      less \
       curl \
       jq \
       py-pip \


### PR DESCRIPTION
This adds support for `aws help` or `aws s3 help`. Without this, attempting to run `docker run -it cgswong/docker-aws aws help` results in an error `Could not find executable named "groff"`
