### PR TITLE
Install groff and set PAGER='more' to fix `aws help`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,13 @@
 FROM gliderlabs/alpine:3.3
 MAINTAINER Stuart Wong <cgs.wong@gmail.com>
 
+ENV PAGER="more"
+
 RUN apk --no-cache add \
       bash \
       curl \
       jq \
+      groff \
       py-pip \
       python &&\
     pip install --upgrade \


### PR DESCRIPTION
`aws help` PAGER defaults to `less -R`, and `less` on Alpine does not support this parameter.

Not useful most of the time as `awscli` is an entry point, however is useful sometimes when debugging and using `bash` as an entry point. `groff` doesn't add much weight either.
