### PR TITLE
added unzip to fix zip error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ RUN apk --no-cache add \
       jq \
       py-pip \
       python \
+      unzip \
       openssh &&\
     pip install --upgrade \
       awscli \


### PR DESCRIPTION
fixed error:
`unzip: invalid zip magic 6D783F3C` (see https://circleci.com/gh/cgswong/docker-aws/93)

using the following workaround: https://github.com/wahern/luaossl/issues/103#issue-254805098