### PR TITLE
Fix URL in Dockerfile and update pip install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,13 +23,15 @@ RUN apk --no-cache add \
       py-pip \
       python \
       openssh &&\
-    pip install --upgrade \
-      awscli \
+    pip install --upgrade --no-cache-dir \
       pip \
+      setuptools &&\
+    pip install --upgrade --no-cache-dir \
+      awscli \
       python-dateutil &&\
     ln -s /usr/bin/aws_bash_completer /etc/profile.d/aws_bash_completer.sh &&\
     curl -sSL --output ${S3_TMP} https://github.com/s3tools/s3cmd/archive/master.zip &&\
-    curl -sSL --output ${RDS_TMP} http://s3.amazonaws.com/rds-downloads/RDSCli.zip &&\
+    curl -sSL --output ${RDS_TMP} https://s3.amazonaws.com/rds-downloads/RDSCli.zip &&\
     unzip -q ${S3_TMP} -d /tmp &&\
     unzip -q ${RDS_TMP} -d /tmp &&\
     mv ${S3_ZIP}/S3 ${S3_ZIP}/s3cmd /usr/bin/ &&\


### PR DESCRIPTION
 - The URL for the RDS CLI was missing the `s` in `https`
 - Update the pip installs to not cache the downloaded packages
 - The old Dockerfile was installing an upgraded pip along side the
   aws-cli and dateutils packages. This means the pip version will get
   updated, but it is still the old version of pip that is installing
   the packages. Update the flow to first upgrade pip and setuptools,
   and then on a new line install the intended packages

By adding `--no-cache-dir` to the pip install commands it saves roughly 10 MB:
```
➜  docker-aws git:(circleci-v2-https-fix) docker images
REPOSITORY       TAG                     IMAGE ID            CREATED             SIZE
cgswong/aws      without-pip-cache       b2e77b56576e        5 minutes ago       219MB
cgswong/aws      with-pip-cache          dccb1da8d142        12 minutes ago      227MB

```