### PR TITLE
Updated version variable for correct build tag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
     machine: true
     environment:
       APP_NAME: aws
-      APP_VERSION: 1.16.26
+      APP_VERSION: 1.16.39
     steps:
       - checkout
       - run:
@@ -31,7 +31,7 @@ jobs:
     machine: true
     environment:
       APP_NAME: aws
-      APP_VERSION: 1.16.26
+      APP_VERSION: 1.16.39
     steps:
       - checkout
       - deploy:


### PR DESCRIPTION
Currently the container pulls the most recent version at build time and the release.md and circle ci file have to be updated afterwards. Using a requirements.txt with fixed versions and a github add on dependency manager might be better.